### PR TITLE
22764 fix crop to aoi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,6 @@ dmypy.json
 .pyre/
 
 .idea/
+
+.devcontainer/
+data/

--- a/EBI.ipynb
+++ b/EBI.ipynb
@@ -10,7 +10,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -53,7 +53,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -70,22 +70,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "AOI = \"POLYGON ((-120.513857 37.594197, -120.513857 37.603083, -120.499386 37.603083, -120.499386 37.594197, -120.513857 37.594197))\"\n",
-    "START_DATE=\"2023-02-16\"\n",
-    "END_DATE=\"2023-02-16\"\n",
-    "SENTINEL2_GOOGLE_API_KEY=\"/workspaces/sip_blooming_index/sentinel2_google_api_key.json\"\n",
-    "SATELLITE_CACHE_FOLDER=\"/workspaces/sip_blooming_index/data/satellite_imagery\"\n",
-    "\n",
-    "OUTPUT_FOLDER=\"/workspaces/sip_blooming_index/data/results\""
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -107,18 +92,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/usr/local/lib/python3.8/site-packages/geopandas/io/file.py:234: FutureWarning: pandas.Int64Index is deprecated and will be removed from pandas in a future version. Use pandas.Index with the appropriate dtype instead.\n",
-      "  pd.Int64Index,\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "aoi = gp.GeoDataFrame(geometry=[wkt.loads(AOI)], crs=\"epsg:4326\")    \n",
     "aoi_filename = \"provided_aoi.geojson\"\n",
@@ -127,7 +103,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -144,7 +120,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -162,7 +138,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -180,7 +156,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -200,7 +176,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -210,7 +186,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -329,60 +305,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Loading images for tile: 10SGG...\n",
-      "For tile: 10SGG and dates 2023-02-16 2023-02-16 proper images not found! Shift dates to 2023-01-17 2023-02-16!\n",
-      "Loading images for tile 10SGG finished\n",
-      "Validating images for tile: 10SGG...\n",
-      "Validating images for tile 10SGG finished\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "loadings = load_images(overlap_tiles.Name.values, START_DATE, END_DATE, aoi)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'10SGG': ['/workspaces/sip_blooming_index/data/satellite_imagery/S2A_MSIL2A_20230215T184441_N0509_R070_T10SGG_20230215T224152/T10SGG_20230215T184441_TCI_10m.jp2',\n",
-       "  '/workspaces/sip_blooming_index/data/satellite_imagery/S2A_MSIL2A_20230215T184441_N0509_R070_T10SGG_20230215T224152/MTD_TL.xml',\n",
-       "  '/workspaces/sip_blooming_index/data/satellite_imagery/S2B_MSIL2A_20230131T184619_N0509_R070_T10SGG_20230131T213704/MTD_TL.xml',\n",
-       "  '/workspaces/sip_blooming_index/data/satellite_imagery/S2B_MSIL2A_20230131T184619_N0509_R070_T10SGG_20230131T213704/T10SGG_20230131T184619_TCI_10m.jp2',\n",
-       "  '/workspaces/sip_blooming_index/data/satellite_imagery/S2B_MSIL2A_20230124T185649_N0509_R113_T10SGG_20230124T210121/MTD_TL.xml',\n",
-       "  '/workspaces/sip_blooming_index/data/satellite_imagery/S2B_MSIL2A_20230124T185649_N0509_R113_T10SGG_20230124T210121/T10SGG_20230124T185649_TCI_10m.jp2',\n",
-       "  '/workspaces/sip_blooming_index/data/satellite_imagery/S2B_MSIL2A_20230210T184519_N0509_R070_T10SGG_20230210T224133/MTD_TL.xml',\n",
-       "  '/workspaces/sip_blooming_index/data/satellite_imagery/S2B_MSIL2A_20230210T184519_N0509_R070_T10SGG_20230210T224133/T10SGG_20230210T184519_TCI_10m.jp2',\n",
-       "  '/workspaces/sip_blooming_index/data/satellite_imagery/S2A_MSIL2A_20230205T184551_N0509_R070_T10SGG_20230205T223747/MTD_TL.xml',\n",
-       "  '/workspaces/sip_blooming_index/data/satellite_imagery/S2A_MSIL2A_20230205T184551_N0509_R070_T10SGG_20230205T223747/T10SGG_20230205T184551_TCI_10m.jp2',\n",
-       "  '/workspaces/sip_blooming_index/data/satellite_imagery/S2B_MSIL2A_20230213T185459_N0509_R113_T10SGG_20230213T213646/MTD_TL.xml',\n",
-       "  '/workspaces/sip_blooming_index/data/satellite_imagery/S2B_MSIL2A_20230213T185459_N0509_R113_T10SGG_20230213T213646/T10SGG_20230213T185459_TCI_10m.jp2',\n",
-       "  '/workspaces/sip_blooming_index/data/satellite_imagery/S2A_MSIL2A_20230119T185711_N0509_R113_T10SGG_20230119T215850/MTD_TL.xml',\n",
-       "  '/workspaces/sip_blooming_index/data/satellite_imagery/S2A_MSIL2A_20230119T185711_N0509_R113_T10SGG_20230119T215850/T10SGG_20230119T185711_TCI_10m.jp2',\n",
-       "  '/workspaces/sip_blooming_index/data/satellite_imagery/S2A_MSIL2A_20230208T185531_N0509_R113_T10SGG_20230208T225853/MTD_TL.xml',\n",
-       "  '/workspaces/sip_blooming_index/data/satellite_imagery/S2A_MSIL2A_20230208T185531_N0509_R113_T10SGG_20230208T225853/T10SGG_20230208T185531_TCI_10m.jp2',\n",
-       "  '/workspaces/sip_blooming_index/data/satellite_imagery/S2A_MSIL2A_20230126T184641_N0509_R070_T10SGG_20230126T222406/MTD_TL.xml',\n",
-       "  '/workspaces/sip_blooming_index/data/satellite_imagery/S2A_MSIL2A_20230126T184641_N0509_R070_T10SGG_20230126T222406/T10SGG_20230126T184641_TCI_10m.jp2',\n",
-       "  '/workspaces/sip_blooming_index/data/satellite_imagery/S2B_MSIL2A_20230121T184659_N0509_R070_T10SGG_20230121T210043/T10SGG_20230121T184659_TCI_10m.jp2',\n",
-       "  '/workspaces/sip_blooming_index/data/satellite_imagery/S2B_MSIL2A_20230121T184659_N0509_R070_T10SGG_20230121T210043/MTD_TL.xml']}"
-      ]
-     },
-     "execution_count": 13,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "loadings"
    ]
@@ -397,7 +331,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -431,21 +365,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'TCI': ['/workspaces/sip_blooming_index/data/satellite_imagery/S2A_MSIL2A_20230215T184441_N0509_R070_T10SGG_20230215T224152/T10SGG_20230215T184441_TCI_10m.jp2'],\n",
-       " 'date': '20230215'}"
-      ]
-     },
-     "execution_count": 15,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "filtered = filter_by_date(loadings)\n",
     "filtered"
@@ -469,7 +391,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -486,7 +408,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -495,27 +417,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "(256, 3)"
-      ]
-     },
-     "execution_count": 18,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "COLORS.shape"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -532,7 +443,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -548,7 +459,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -560,7 +471,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -572,7 +483,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -598,7 +509,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -638,7 +549,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -698,7 +609,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -736,18 +647,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Start calculation EBI\n",
-      "End calculation EBI\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "if not filtered:\n",
     "    geojson_path = os.path.join(OUTPUT_NODATA_FOLDER, \"aoi.geojson\")\n",

--- a/EBI.ipynb
+++ b/EBI.ipynb
@@ -1,6 +1,7 @@
 {
  "cells": [
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -12,37 +13,27 @@
    "execution_count": 1,
    "metadata": {},
    "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "import os\n",
     "import geopandas as gp\n",
     "import numpy as np\n",
     "import rasterio\n",
     "import re\n",
-    "import tempfile\n",
     "import pyproj\n",
-    "import uuid\n",
     "import json\n",
     "import geojson\n",
     "import shutil\n",
+    "import tempfile\n",
+    "import uuid\n",
     "\n",
     "from geojson import Feature\n",
     "\n",
     "import rasterio.mask\n",
-    "from rasterio import Affine\n",
     "from rasterio.plot import reshape_as_raster\n",
     "from rasterio.merge import merge\n",
     "from rasterio.warp import calculate_default_transform, reproject, Resampling\n",
-    "from rasterio.profiles import DefaultGTiffProfile\n",
     "\n",
     "from shapely import wkt\n",
-    "from shapely.geometry import Polygon, box\n",
     "from shapely.ops import transform\n",
     "\n",
     "\n",
@@ -53,6 +44,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -61,12 +53,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
-    "\n",
-    "\n",
     "# Inputs\n",
     "AOI = os.getenv('AOI')\n",
     "START_DATE = os.getenv(\"START_DATE\")\n",
@@ -75,9 +65,30 @@
     "SATELLITE_CACHE_FOLDER = os.getenv('SENTINEL2_CACHE')\n",
     "\n",
     "# Output folder\n",
-    "OUTPUT_FOLDER = os.getenv('OUTPUT_FOLDER')\n",
+    "OUTPUT_FOLDER = os.getenv('OUTPUT_FOLDER')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "AOI = \"POLYGON ((-120.513857 37.594197, -120.513857 37.603083, -120.499386 37.603083, -120.499386 37.594197, -120.513857 37.594197))\"\n",
+    "START_DATE=\"2023-02-16\"\n",
+    "END_DATE=\"2023-02-16\"\n",
+    "SENTINEL2_GOOGLE_API_KEY=\"/workspaces/sip_blooming_index/sentinel2_google_api_key.json\"\n",
+    "SATELLITE_CACHE_FOLDER=\"/workspaces/sip_blooming_index/data/satellite_imagery\"\n",
     "\n",
-    "\n",
+    "OUTPUT_FOLDER=\"/workspaces/sip_blooming_index/data/results\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "OUTPUT_NODATA_FOLDER = os.path.join(OUTPUT_FOLDER, \"/nodata\")\n",
     "OUTPUT_EBI_FILE = os.path.join(OUTPUT_FOLDER, \"EBI.tif\")\n",
     "OUTPUT_TCI_FILE = os.path.join(OUTPUT_FOLDER, \"TCI.tif\")\n",
@@ -87,6 +98,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -95,9 +107,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 5,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/usr/local/lib/python3.8/site-packages/geopandas/io/file.py:234: FutureWarning: pandas.Int64Index is deprecated and will be removed from pandas in a future version. Use pandas.Index with the appropriate dtype instead.\n",
+      "  pd.Int64Index,\n"
+     ]
+    }
+   ],
    "source": [
     "aoi = gp.GeoDataFrame(geometry=[wkt.loads(AOI)], crs=\"epsg:4326\")    \n",
     "aoi_filename = \"provided_aoi.geojson\"\n",
@@ -106,7 +127,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -114,6 +135,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -122,134 +144,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "def epsg_code(longitude, latitude):\n",
-    "        \"\"\"\n",
-    "        Generates EPSG code from lon, lat\n",
-    "        :param longitude: float\n",
-    "        :param latitude: float\n",
-    "        :return: int, EPSG code\n",
-    "        \"\"\"\n",
-    "\n",
-    "        def _zone_number(lat, lon):\n",
-    "            if 56 <= lat < 64 and 3 <= lon < 12:\n",
-    "                return 32\n",
-    "            if 72 <= lat <= 84 and lon >= 0:\n",
-    "                if lon < 9:\n",
-    "                    return 31\n",
-    "                elif lon < 21:\n",
-    "                    return 33\n",
-    "                elif lon < 33:\n",
-    "                    return 35\n",
-    "                elif lon < 42:\n",
-    "                    return 37\n",
-    "\n",
-    "            return int((lon + 180) / 6) + 1\n",
-    "\n",
-    "        zone = _zone_number(latitude, longitude)\n",
-    "\n",
-    "        if latitude > 0:\n",
-    "            return 32600 + zone\n",
-    "        else:\n",
-    "            return 32700 + zone"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 9,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>tile</th>\n",
-       "      <th>geometry</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>10SGF</td>\n",
-       "      <td>POLYGON ((-120.21176 36.36394, -120.20301 36.3...</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "    tile                                           geometry\n",
-       "0  10SGF  POLYGON ((-120.21176 36.36394, -120.20301 36.3..."
-      ]
-     },
-     "execution_count": 9,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
    "source": [
     "s2overlap = Sentinel2Overlap(aoi_path=aoi_filename)\n",
-    "overlap_tiles = s2overlap.overlap_with_geometry()\n"
+    "overlap_tiles = s2overlap.overlap_with_geometry()"
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 10,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<Geographic 2D CRS: EPSG:4326>\n",
-       "Name: WGS 84\n",
-       "Axis Info [ellipsoidal]:\n",
-       "- Lat[north]: Geodetic latitude (degree)\n",
-       "- Lon[east]: Geodetic longitude (degree)\n",
-       "Area of Use:\n",
-       "- name: World.\n",
-       "- bounds: (-180.0, -90.0, 180.0, 90.0)\n",
-       "Datum: World Geodetic System 1984 ensemble\n",
-       "- Ellipsoid: WGS 84\n",
-       "- Prime Meridian: Greenwich"
-      ]
-     },
-     "execution_count": 10,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "overlap_tiles.crs"
-   ]
-  },
-  {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -258,63 +162,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
-    "# API_KEY = os.path.join(BASE, \".secret/sentinel2_google_api_key.json\")\n",
     "LOAD_DIR = SATELLITE_CACHE_FOLDER\n",
     "\n",
-    "PRODUCT_TYPE = 'L2A'\n",
     "BANDS = {\"TCI\"}\n",
-    "CONSTRAINTS = {'NODATA_PIXEL_PERCENTAGE': 10.0, 'CLOUDY_PIXEL_PERCENTAGE': 5.0, }\n",
+    "NODATA_PIXEL_PERCENTAGE = 10.0\n",
+    "SEARCH_CLOUDY_PIXEL_PERCENTAGE = 80.0\n",
+    "AOI_CLOUDY_PIXEL_PERCENTAGE = 15.0\n",
+    "CONSTRAINTS = {'CLOUDY_PIXEL_PERCENTAGE': SEARCH_CLOUDY_PIXEL_PERCENTAGE}\n",
+    "PRODUCT_TYPE = 'L2A'\n",
     "\n",
     "LAYERS = ['EBI', 'TCI']"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'2020-01-20'"
-      ]
-     },
-     "execution_count": 12,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "START_DATE"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 13,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'2020-02-05'"
-      ]
-     },
-     "execution_count": 13,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "END_DATE"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -325,6 +191,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -333,48 +200,116 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
-    "MAX_SHIFT = 30"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 16,
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "MAX_SHIFT = 30\n",
     "MAX_SHIFT_ITERS = 2"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
-    "def load_images(tiles, start_date, end_date):\n",
-    "    loader = Sentinel2Downloader(SENTINEL2_GOOGLE_API_KEY)\n",
+    "def dump_no_data_geojson(polygon, geojson_path):\n",
+    "    NO_DATA = 'No data'\n",
+    "    style = dict(color='red')\n",
+    "    feature = Feature(geometry=polygon, properties=dict(label=NO_DATA, style=style))\n",
+    "    feature['start_date'] = START_DATE\n",
+    "    feature['end_date'] = END_DATE\n",
+    "    feature['name'] = NO_DATA\n",
     "    \n",
+    "    with open(geojson_path, 'w') as f:\n",
+    "        geojson.dump(feature, f)\n",
+    "\n",
+    "def check_nodata_percentage_crop(tile_path, \n",
+    "                                 aoi, \n",
+    "                                 nodata_percentage_limit, \n",
+    "                                 nodata):\n",
+    "    with rasterio.open(tile_path) as src:\n",
+    "        polygon = aoi.to_crs(src.meta['crs']).geometry[0]\n",
+    "        band, _ = rasterio.mask.mask(src, [polygon], crop=True, filled=False, indexes=1)\n",
+    "        masked_band = band[~band.mask]\n",
+    "        nodata_count = np.count_nonzero(masked_band == nodata)\n",
+    "        nodata_percentage = round(nodata_count / masked_band.size * 100, 2)\n",
+    "    if nodata_percentage>=nodata_percentage_limit:\n",
+    "        return True\n",
+    "    else:\n",
+    "        return False\n",
+    "\n",
+    "def check_cloud_percentage_crop(tile_path, \n",
+    "                                aoi, \n",
+    "                                cloud_percentage_limit,\n",
+    "                                cloud_probability=50):\n",
+    "    with rasterio.open(tile_path) as src:\n",
+    "        polygon = aoi.to_crs(src.meta['crs']).geometry[0]\n",
+    "        band, _ = rasterio.mask.mask(src, [polygon], crop=True, filled=False, indexes=1)\n",
+    "        masked_band = band[~band.mask]\n",
+    "        cloud_count = np.count_nonzero(masked_band >= cloud_probability)\n",
+    "        cloud_percentage = round(cloud_count / masked_band.size * 100, 2)\n",
+    "    if cloud_percentage>=cloud_percentage_limit:\n",
+    "        return True\n",
+    "    else:\n",
+    "        return False\n",
+    "\n",
+    "def check_tile_validity(tile_folder, aoi, cloud_percentage_limit, nodata_percentage_limit):\n",
+    "    band_paths = [os.path.join(tile_folder, i) for i in os.listdir(tile_folder)]\n",
+    "    skip_tile = False\n",
+    "    for band_path in band_paths:\n",
+    "        if  '.jp2' != Path(band_path).suffix:\n",
+    "            continue\n",
+    "        if \"MSK_CLDPRB_20m\" in band_path:\n",
+    "            cloud_check = check_cloud_percentage_crop(band_path, aoi, cloud_percentage_limit)\n",
+    "            if cloud_check:\n",
+    "                skip_tile=True\n",
+    "                break\n",
+    "        else:\n",
+    "            nodata_check = check_nodata_percentage_crop(band_path, aoi, nodata_percentage_limit, 0)\n",
+    "            if nodata_check:\n",
+    "                skip_tile=True\n",
+    "                break\n",
+    "    return skip_tile, band_paths\n",
+    "\n",
+    "def validate_tile_downloads(loaded, tile, loadings, aoi, cloud_percentage_limit, nodata_percentage_limit):\n",
+    "    print(f\"Validating images for tile: {tile}...\")\n",
+    "    if not loaded:\n",
+    "        print(f\"Images for tile {tile} were not loaded!\")\n",
+    "        return loadings\n",
+    "    loaded_tile_folders = set([Path(i[0]).parent for i in loaded])\n",
+    "    tile_bands = []\n",
+    "    for loaded_tile_folder in loaded_tile_folders:\n",
+    "        skip_tile, band_paths = check_tile_validity(loaded_tile_folder, aoi, cloud_percentage_limit, nodata_percentage_limit)\n",
+    "        if skip_tile:\n",
+    "            shutil.rmtree(loaded_tile_folder)\n",
+    "        else:\n",
+    "            tile_bands += band_paths\n",
+    "    if tile_bands:\n",
+    "        loadings[tile] = tile_bands\n",
+    "    else:\n",
+    "        print(f\"Tile images didn't match nodata/cloud constraints, so they were removed\") \n",
+    "    print(f\"Validating images for tile {tile} finished\")  \n",
+    "    return loadings\n",
+    "\n",
+    "def load_images(tiles, start_date, end_date, aoi):\n",
+    "    loader = Sentinel2Downloader(SENTINEL2_GOOGLE_API_KEY)\n",
     "    loadings = dict()\n",
-    "        \n",
+    "\n",
     "    for tile in tiles:\n",
-    "        start = start_date\n",
-    "        end = end_date\n",
-    "        \n",
     "        print(f\"Loading images for tile: {tile}...\")\n",
     "        count = 0\n",
+    "        start = start_date\n",
+    "        end = end_date\n",
     "        while count < MAX_SHIFT_ITERS:\n",
     "            loaded = loader.download(PRODUCT_TYPE,\n",
     "                                [tile],\n",
     "                                start_date=start,\n",
     "                                end_date=end,\n",
-    "                                output_dir=LOAD_DIR,                       \n",
+    "                                output_dir=SATELLITE_CACHE_FOLDER,               \n",
     "                                bands=BANDS,\n",
     "                                constraints=CONSTRAINTS)\n",
-    "        \n",
     "            if not loaded:\n",
     "                end = start_date\n",
     "                start = shift_date(start_date, delta=MAX_SHIFT) \n",
@@ -382,37 +317,78 @@
     "            else:\n",
     "                break\n",
     "            count += 1\n",
-    "        if loaded:\n",
-    "            loadings[tile] = loaded\n",
-    "            print(f\"Loading images for tile {tile} finished\")\n",
+    "        print(f\"Loading images for tile {tile} finished\")\n",
+    "        if count < MAX_SHIFT_ITERS:\n",
+    "            loadings = validate_tile_downloads(loaded, tile, loadings, aoi, AOI_CLOUDY_PIXEL_PERCENTAGE, NODATA_PIXEL_PERCENTAGE)\n",
     "        else:\n",
-    "            print(f\"Images for tile {tile} were not loaded!\")\n",
-    "        \n",
-    "    # tile_folders = dict()\n",
-    "    # for tile, tile_paths in loadings.items():\n",
-    "    #    tile_folders[tile] = {str(Path(tile_path[0]).parent) for tile_path in tile_paths}\n",
+    "            geojson_path = os.path.join(OUTPUT_FOLDER, f\"{START_DATE}_{END_DATE}_no_data.geojson\")\n",
+    "            dump_no_data_geojson(aoi.geometry[0], geojson_path)\n",
+    "            raise ValueError(\"Images not loaded for given AOI. Change dates, constraints\")\n",
     "    return loadings"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Loading images for tile: 10SGF...\n",
-      "Loading images for tile 10SGF finished\n"
+      "Loading images for tile: 10SGG...\n",
+      "For tile: 10SGG and dates 2023-02-16 2023-02-16 proper images not found! Shift dates to 2023-01-17 2023-02-16!\n",
+      "Loading images for tile 10SGG finished\n",
+      "Validating images for tile: 10SGG...\n",
+      "Validating images for tile 10SGG finished\n"
      ]
     }
    ],
    "source": [
-    "loadings = load_images(overlap_tiles.Name.values, START_DATE, END_DATE)"
+    "loadings = load_images(overlap_tiles.Name.values, START_DATE, END_DATE, aoi)"
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'10SGG': ['/workspaces/sip_blooming_index/data/satellite_imagery/S2A_MSIL2A_20230215T184441_N0509_R070_T10SGG_20230215T224152/T10SGG_20230215T184441_TCI_10m.jp2',\n",
+       "  '/workspaces/sip_blooming_index/data/satellite_imagery/S2A_MSIL2A_20230215T184441_N0509_R070_T10SGG_20230215T224152/MTD_TL.xml',\n",
+       "  '/workspaces/sip_blooming_index/data/satellite_imagery/S2B_MSIL2A_20230131T184619_N0509_R070_T10SGG_20230131T213704/MTD_TL.xml',\n",
+       "  '/workspaces/sip_blooming_index/data/satellite_imagery/S2B_MSIL2A_20230131T184619_N0509_R070_T10SGG_20230131T213704/T10SGG_20230131T184619_TCI_10m.jp2',\n",
+       "  '/workspaces/sip_blooming_index/data/satellite_imagery/S2B_MSIL2A_20230124T185649_N0509_R113_T10SGG_20230124T210121/MTD_TL.xml',\n",
+       "  '/workspaces/sip_blooming_index/data/satellite_imagery/S2B_MSIL2A_20230124T185649_N0509_R113_T10SGG_20230124T210121/T10SGG_20230124T185649_TCI_10m.jp2',\n",
+       "  '/workspaces/sip_blooming_index/data/satellite_imagery/S2B_MSIL2A_20230210T184519_N0509_R070_T10SGG_20230210T224133/MTD_TL.xml',\n",
+       "  '/workspaces/sip_blooming_index/data/satellite_imagery/S2B_MSIL2A_20230210T184519_N0509_R070_T10SGG_20230210T224133/T10SGG_20230210T184519_TCI_10m.jp2',\n",
+       "  '/workspaces/sip_blooming_index/data/satellite_imagery/S2A_MSIL2A_20230205T184551_N0509_R070_T10SGG_20230205T223747/MTD_TL.xml',\n",
+       "  '/workspaces/sip_blooming_index/data/satellite_imagery/S2A_MSIL2A_20230205T184551_N0509_R070_T10SGG_20230205T223747/T10SGG_20230205T184551_TCI_10m.jp2',\n",
+       "  '/workspaces/sip_blooming_index/data/satellite_imagery/S2B_MSIL2A_20230213T185459_N0509_R113_T10SGG_20230213T213646/MTD_TL.xml',\n",
+       "  '/workspaces/sip_blooming_index/data/satellite_imagery/S2B_MSIL2A_20230213T185459_N0509_R113_T10SGG_20230213T213646/T10SGG_20230213T185459_TCI_10m.jp2',\n",
+       "  '/workspaces/sip_blooming_index/data/satellite_imagery/S2A_MSIL2A_20230119T185711_N0509_R113_T10SGG_20230119T215850/MTD_TL.xml',\n",
+       "  '/workspaces/sip_blooming_index/data/satellite_imagery/S2A_MSIL2A_20230119T185711_N0509_R113_T10SGG_20230119T215850/T10SGG_20230119T185711_TCI_10m.jp2',\n",
+       "  '/workspaces/sip_blooming_index/data/satellite_imagery/S2A_MSIL2A_20230208T185531_N0509_R113_T10SGG_20230208T225853/MTD_TL.xml',\n",
+       "  '/workspaces/sip_blooming_index/data/satellite_imagery/S2A_MSIL2A_20230208T185531_N0509_R113_T10SGG_20230208T225853/T10SGG_20230208T185531_TCI_10m.jp2',\n",
+       "  '/workspaces/sip_blooming_index/data/satellite_imagery/S2A_MSIL2A_20230126T184641_N0509_R070_T10SGG_20230126T222406/MTD_TL.xml',\n",
+       "  '/workspaces/sip_blooming_index/data/satellite_imagery/S2A_MSIL2A_20230126T184641_N0509_R070_T10SGG_20230126T222406/T10SGG_20230126T184641_TCI_10m.jp2',\n",
+       "  '/workspaces/sip_blooming_index/data/satellite_imagery/S2B_MSIL2A_20230121T184659_N0509_R070_T10SGG_20230121T210043/T10SGG_20230121T184659_TCI_10m.jp2',\n",
+       "  '/workspaces/sip_blooming_index/data/satellite_imagery/S2B_MSIL2A_20230121T184659_N0509_R070_T10SGG_20230121T210043/MTD_TL.xml']}"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "loadings"
+   ]
+  },
+  {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -421,7 +397,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -437,22 +413,17 @@
     "        last_date = datetime.strftime(last_date, '%Y%m%d')\n",
     "        return last_date\n",
     "    \n",
-    "    filtered = dict()\n",
+    "    filtered = {\n",
+    "        'TCI': []\n",
+    "    }\n",
     "    for tile, items in loadings.items():\n",
     "        try:\n",
     "            last_date = _find_last_date(items)\n",
-    "            bands_paths = dict()\n",
-    "            for path, _ in items:\n",
+    "            for path in items:\n",
     "                if last_date in path:\n",
-    "                    if 'B04_10m.jp2' in path:\n",
-    "                        bands_paths['RED'] = path\n",
-    "                    if 'B03_10m.jp2' in path:\n",
-    "                        bands_paths['GREEN'] = path\n",
-    "                    if 'B02_10m.jp2' in path:\n",
-    "                        bands_paths['BLUE'] = path\n",
     "                    if 'TCI_10m.jp2' in path:\n",
-    "                        bands_paths['TCI'] = path\n",
-    "            filtered[tile] = dict(paths=bands_paths, date=last_date)\n",
+    "                        filtered['TCI'] += [path]\n",
+    "            filtered['date'] = last_date\n",
     "        except Exception as ex:\n",
     "            print(f\"Error for {tile}: {str(ex)}\")\n",
     "    return filtered"
@@ -460,14 +431,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 15,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'TCI': ['/workspaces/sip_blooming_index/data/satellite_imagery/S2A_MSIL2A_20230215T184441_N0509_R070_T10SGG_20230215T224152/T10SGG_20230215T184441_TCI_10m.jp2'],\n",
+       " 'date': '20230215'}"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "filtered = filter_by_date(loadings)"
+    "filtered = filter_by_date(loadings)\n",
+    "filtered"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -475,16 +460,7 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 21,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "TEMP_DIR = \"/temp\"\n",
-    "os.makedirs(TEMP_DIR, exist_ok=True)"
-   ]
-  },
-  {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -493,7 +469,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -510,7 +486,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -519,7 +495,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [
     {
@@ -528,7 +504,7 @@
        "(256, 3)"
       ]
      },
-     "execution_count": 24,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -539,7 +515,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -556,7 +532,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -567,17 +543,16 @@
     "    scaled = np.around(scaled)\n",
     "    scaled[np.isnan(scaled) == True] = nodata\n",
     "    scaled = scaled.astype(np.uint8)\n",
-    "    print(scaled.max())\n",
     "    return scaled"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [],
    "source": [
-    "def color_ndvi(scaled, colors):\n",
+    "def color_ebi(scaled, colors):\n",
     "    colored = np.reshape(colors[scaled.flatten()], tuple((*scaled.shape, 3)))\n",
     "    colored = reshape_as_raster(colored)\n",
     "    return colored"
@@ -585,12 +560,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [],
    "source": [
     "def to_crs(poly, target, current='EPSG:4326'):\n",
-    "    # print(f\"TARGET CRS: {target}\")\n",
     "    project = pyproj.Transformer.from_crs(pyproj.CRS(current), pyproj.CRS(target), always_xy=True).transform\n",
     "    transformed_poly = transform(project, poly)\n",
     "    return transformed_poly "
@@ -598,7 +572,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -624,7 +598,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -664,7 +638,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -724,25 +698,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "def dump_no_data_geosjon(polygon, geojson_path):\n",
-    "    NO_DATA = 'No data'\n",
-    "    style = dict(color='red')\n",
-    "    feature = Feature(geometry=polygon, properties=dict(label=NO_DATA, style=style))\n",
-    "    feature['start_date'] = START_DATE\n",
-    "    feature['end_date'] = END_DATE\n",
-    "    feature['name'] = NO_DATA\n",
-    "    \n",
-    "    with open(geojson_path, 'w') as f:\n",
-    "        geojson.dump(feature, f)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -755,9 +711,8 @@
     "        crs = str(src.crs)\n",
     "    EBI = (red + green + blue) / ((green / blue) * (red - blue + eps))\n",
     "    EBI = scale(EBI)\n",
-    "    print(EBI.max())\n",
-    "    print(EBI.min())\n",
-    "    colored = color_ndvi(EBI, COLORS)\n",
+    "\n",
+    "    colored = color_ebi(EBI, COLORS)\n",
     "    out_meta = src.meta.copy()\n",
     "    out_meta.update(dtype=rasterio.uint8,\n",
     "                    driver='GTiff',\n",
@@ -770,17 +725,7 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "def clean_images(images):\n",
-    "    for i in range(len(images)):\n",
-    "        os.remove(images[i])"
-   ]
-  },
-  {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -791,85 +736,54 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 27,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "10SGF: Start calculation EBI\n",
-      "nan nan\n",
-      "False\n",
-      "[[0.06540084 0.38192929 0.37794473 ... 0.02233773 0.2384486  0.01353603]\n",
-      " [0.15214531 2.437046   0.19571892 ... 0.33867028 0.38764995 0.36047431]\n",
-      " [0.19945355 2.66359447 2.93524044 ... 0.09519022 0.00705271 0.47389163]\n",
-      " ...\n",
-      " [0.58958775 0.63071895 0.91467181 ... 0.11168488 0.47247247 0.13086932]\n",
-      " [0.152872   0.62857143 0.2742941  ... 0.09501558 0.15121951 0.25673798]\n",
-      " [0.38472419 0.84745604 0.21332728 ... 0.35053027 0.26453129 1.74070284]]\n",
-      "255\n",
-      "10SGF: End calculation EBI\n",
-      "10SGF: Rename /home/ritalatuha/quantum/sip_blooming_index/./results/45/45_10SGF_20200201_EBI.tif.temp->/home/ritalatuha/quantum/sip_blooming_index/./results/45/45_10SGF_20200201_EBI.tif\n",
-      "\n"
+      "Start calculation EBI\n",
+      "End calculation EBI\n"
      ]
     }
    ],
    "source": [
-    "\n",
     "if not filtered:\n",
     "    geojson_path = os.path.join(OUTPUT_NODATA_FOLDER, \"aoi.geojson\")\n",
-    "    dump_no_data_geosjon(aoi.geometry[0], geojson_path)    \n",
+    "    dump_no_data_geojson(aoi.geometry[0], geojson_path)\n",
     "    raise ValueError(\"Images not loaded for given AOI. Change dates, constraints\")\n",
     "\n",
-    "images_tci = []\n",
-    "images = []\n",
-    "for row in overlap_tiles.itertuples():\n",
-    "    tile = row.Name\n",
-    "    polygon = row.geometry\n",
-    "    if not tile in filtered:\n",
-    "        tile_geojson_path = os.path.join(OUTPUT_NODATA_FOLDER, \"%s_aoi.geojson\" % tile)\n",
-    "        print(\"No data loaded for tile\", tile)\n",
-    "        dump_no_data_geosjon(polygon, tile_geojson_path)    \n",
-    "    \n",
-    "    try:\n",
-    "        paths = filtered[tile]['paths']\n",
-    "        print(f\"{tile}: Start calculation EBI\")\n",
-    "        \n",
-    "        acquired_date = filtered[tile]['date']\n",
-    "        base_filename = f\"{tile}_{acquired_date}_\"\n",
-    "        temp_filename = os.path.join(TEMP_DIR, base_filename + \"EBI.tif.temp\")\n",
-    "        temp_filename_tci = os.path.join(TEMP_DIR, base_filename + \"TCI.tif.temp\")\n",
-    "        \n",
-    "        with rasterio.open(paths['TCI']) as src:\n",
-    "            tile_crs = str(src.crs)\n",
-    "        transformed_poly = to_crs(polygon, tile_crs)\n",
+    "with tempfile.TemporaryDirectory() as tmp_dir:\n",
+    "    images_tci = []\n",
+    "    images_ebi = []\n",
+    "    polygon = wkt.loads(AOI)\n",
+    "    for tci_path in filtered['TCI']:\n",
+    "        try:\n",
+    "            print(\"Start calculation EBI\")\n",
+    "            acquired_date = filtered['date']\n",
+    "            \n",
+    "            with rasterio.open(tci_path) as src:\n",
+    "                tile_crs = str(src.crs)\n",
+    "            transformed_poly = to_crs(polygon, tile_crs)\n",
+    "            temp_cropped_tci = os.path.join(tmp_dir, f\"{uuid.uuid4()}.tif\")\n",
+    "            temp_cropped_ebi = os.path.join(tmp_dir, f\"{uuid.uuid4()}.tif\")\n",
     "\n",
-    "        crop(paths['TCI'], temp_filename_tci, transformed_poly, acquired_date, name=\"Sentinel-2 EBI\", colormap=colormap_tag)\n",
+    "            crop(tci_path, temp_cropped_tci, transformed_poly, acquired_date, name=\"Sentinel-2 EBI\", colormap=colormap_tag)\n",
+    "            calculate_EBI(temp_cropped_tci, temp_cropped_ebi)\n",
+    "            print(\"End calculation EBI\")\n",
     "        \n",
-    "        calculate_EBI(temp_filename_tci, temp_filename)\n",
-    "        print(f\"{tile}: End calculation EBI\")\n",
-    "    \n",
-    "        filename = temp_filename[:-5]\n",
-    "        filename_tci = temp_filename_tci[:-5]\n",
-    "        print(f\"{tile}: Rename {temp_filename}->{filename}\\n\")\n",
-    "        os.rename(temp_filename, filename)\n",
-    "        os.rename(temp_filename_tci, filename_tci)\n",
-    "        images_tci.append(filename_tci)\n",
-    "        images.append(filename)\n",
-    "    except Exception as e:\n",
-    "        print(f\"{tile}: Cannot calculate EBI: {str(e)}\")\n",
+    "            images_tci.append(temp_cropped_tci)\n",
+    "            images_ebi.append(temp_cropped_ebi)\n",
+    "        except Exception as e:\n",
+    "            print(f\"Cannot calculate EBI: {str(e)}\")\n",
     "\n",
-    "if len(images) > 1:\n",
-    "    full_ndvi = stitch_tiles(images, OUTPUT_EBI_FILE, acquired_date, name=\"Sentinel-2 EBI\", colormap=colormap_tag)\n",
-    "    full_tci = stitch_tiles(filename_tci, OUTPUT_TCI_FILE, acquired_date, name=\"Sentinel-2 RGB Raster\")\n",
-    "\n",
-    "else:\n",
-    "    shutil.copy(images[0], OUTPUT_EBI_FILE)\n",
-    "    shutil.copy(images_tci[0], OUTPUT_TCI_FILE)\n",
-    "    \n",
-    "clean_images(images)\n",
-    "clean_images(images_tci)"
+    "    if len(images_ebi) > 1:\n",
+    "        stitch_tiles(images_ebi, OUTPUT_EBI_FILE, acquired_date, name=\"Sentinel-2 EBI\", colormap=colormap_tag)\n",
+    "        stitch_tiles(images_tci, OUTPUT_TCI_FILE, acquired_date, name=\"Sentinel-2 RGB Raster\")\n",
+    "    else:\n",
+    "        shutil.copy(images_ebi[0], OUTPUT_EBI_FILE)\n",
+    "        shutil.copy(images_tci[0], OUTPUT_TCI_FILE)"
    ]
   }
  ],


### PR DESCRIPTION
1. Fix cropping to AoI. The issue was in this line:
https://github.com/QuantuMobileSoftware/sip_blooming_index/compare/22764-fix-crop-to-aoi?expand=1#diff-819f405fa7c12e8d54c5a944e053f19646e6d4d805dc220375e9c48a8e30f02dL829
Tile geometry overwrote AoI geometry and cropping failed, because of it.
2. Remove unused code
3. Add logic from https://github.com/QuantuMobileSoftware/geoap/pull/445 for validation and download of images instead of the old one. Keep date shift logic.
4. Use tempfile.TemporaryDirectory() for handling temporary files.